### PR TITLE
Bugfix for unit tests not working on x86 platform

### DIFF
--- a/platformio/commands/test/command.py
+++ b/platformio/commands/test/command.py
@@ -141,7 +141,7 @@ def cli(  # pylint: disable=redefined-builtin
 
                 cls = (
                     NativeTestProcessor
-                    if config.get(section, "platform") == "native"
+                    if config.get(section, "platform") == "native" or config.get(section, "platform") == "windows_x86"
                     else EmbeddedTestProcessor
                 )
                 tp = cls(


### PR DESCRIPTION
x86 used the wrong TestProcessor class and therefore complained about e.g. upload fails (and upload does not make sense when unit testing on x86). This commit fixes the most prominent bug. There still might be other parts to fix as you need to manually set "test_transport = native" for it to work...